### PR TITLE
fix: Axum router configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "py-crude-resource-monitor"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-crude-resource-monitor"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -37,10 +37,10 @@ pub async fn run_view(output_dir: PathBuf, interface: &str, port: u16) -> Result
         // nest to ensure the prefix is stripped
         .nest(
             "/view",
-            Router::new().route("/*file", get(serve_profile_data)),
+            Router::new().route("/{*file}", get(serve_profile_data)),
         )
         .route("/", get(|| async { FrontendStaticFile("index.html") }))
-        .route("/*file", get(serve_frontend))
+        .route("/{*file}", get(serve_frontend))
         .layer(CorsLayer::very_permissive())
         .with_state(output_dir);
 


### PR DESCRIPTION
got this error:

```
❯ py-crude-resource-monitor view out

thread 'main' panicked at src/view.rs:40:27:
Path segments must not start with `*`. For wildcard capture, use `{*wildcard}`. If you meant to literally match a segment starting with an asterisk, call `without_v07_checks` on the router.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```